### PR TITLE
Ensure osgeo/utils is included

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@ import os
 import sys
 from subprocess import check_output, CalledProcessError
 
-from setuptools import setup, Extension
+from setuptools import setup, Extension, find_packages
 from setuptools.command.build_ext import build_ext
 
 from distutils.errors import CompileError
 
 GDAL_VERSION = open('GDAL_VERSION', 'r').read().strip()
-PKG_VERSION = '6'
+PKG_VERSION = '7'
 
 ENV_GDALHOME = 'GDALHOME'
 
@@ -177,7 +177,7 @@ ext_modules = [
     gdal_array_module,
 ]
 
-packages = ["osgeo", ]
+packages =  find_packages()
 
 name = 'pygdal'
 version = GDAL_VERSION + '.' + PKG_VERSION
@@ -255,6 +255,7 @@ setup(
     setup_requires=requires,
     install_requires=requires,
 
+    include_package_data=True,
     packages=packages,
     ext_modules=ext_modules,
     zip_safe=False,


### PR DESCRIPTION
As of gdal 3.2, `osgeo/utils` needs to be included in the distribution otherwise various tools such as 'gdal_fillnodata.py' will not correctly run. This PR ensures utils is included and does so in a way that is (should be!) backwards compatible with <3.2 due to the use of `find_packages`.